### PR TITLE
option for overwriting existing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ In order to unpack an ipf file to the current directory, you can use:
 
     python ipf.py -xf target.ipf
     or python ipf.py -x -f target.ipf
-    
+
+Unpacking does not overwrite existing files by default, use `--overwrite` if you need that:
+
+    python ipf.py --overwrite -xf target.ipf
+
 You can also specify an output directory with `-C`:
 
     python ipf.py -xf target.ipf -C ./output/dir/

--- a/ipf.py
+++ b/ipf.py
@@ -396,6 +396,7 @@ if __name__ == '__main__':
     parser.add_argument('-b', '--base-revision', type=int, help='base revision number for the archive')
     parser.add_argument('--enable-encryption', action='store_true', help='decrypt/encrypt when extracting/archiving')
     parser.add_argument('--fnfilter', type=str, help='filename filter (eg *.lua)')
+    parser.add_argument('--overwrite', action='store_true', help='overwrite existing files')
 
     parser.add_argument('target', nargs='?', help='target file/directory to be extracted or packed')
 
@@ -430,7 +431,7 @@ if __name__ == '__main__':
             if args.list:
                 print_list(ipf, args)
             elif args.extract:
-                ipf.extract_all(args.directory or '.', fnfilter=args.fnfilter)
+                ipf.extract_all(args.directory or '.', fnfilter=args.fnfilter, overwrite=args.overwrite)
             elif args.create:
                 create_archive(ipf, args)
 


### PR DESCRIPTION
small update. I've noticed that ipf.py doesn't overwrite files while extracting (just like GNU tar). so I've added --overwrite flag